### PR TITLE
Add #7: Move service configuration to Settings with categorized list

### DIFF
--- a/App/Views/ServiceSettingsView.swift
+++ b/App/Views/ServiceSettingsView.swift
@@ -1,0 +1,101 @@
+// ABOUTME: Settings view for managing MCP services, grouped by category.
+// ABOUTME: Displays services with toggles and optional drill-down for granular controls.
+
+import OSLog
+import SwiftUI
+
+private let log = Logger.service("settings")
+
+struct ServiceSettingsView: View {
+    @ObservedObject var serverController: ServerController
+
+    private var serviceConfigs: [ServiceConfig] {
+        serverController.computedServiceConfigs
+    }
+
+    private func services(for category: ServiceCategory) -> [ServiceConfig] {
+        serviceConfigs.filter { $0.category == category }
+    }
+
+    var body: some View {
+        Form {
+            ForEach(ServiceCategory.allCases) { category in
+                let categoryServices = services(for: category)
+                if !categoryServices.isEmpty {
+                    Section(category.rawValue) {
+                        ForEach(categoryServices) { config in
+                            ServiceRowView(config: config)
+                        }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+private struct ServiceRowView: View {
+    let config: ServiceConfig
+    @State private var isServiceActivated = false
+    @State private var activationError: String?
+    @State private var showingErrorAlert = false
+
+    var body: some View {
+        HStack {
+            serviceIcon
+            Text(config.name)
+            Spacer()
+            Toggle("", isOn: config.binding)
+                .toggleStyle(.switch)
+                .labelsHidden()
+            if config.hasDetailView {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if config.hasDetailView {
+                // TODO: Navigate to detail view for granular service controls
+            } else {
+                config.binding.wrappedValue.toggle()
+                if config.binding.wrappedValue && !isServiceActivated {
+                    Task { @MainActor in
+                        do {
+                            try await config.service.activate()
+                            isServiceActivated = true
+                        } catch {
+                            log.error("Failed to activate \(config.name): \(error.localizedDescription)")
+                            config.binding.wrappedValue = false
+                            activationError = error.localizedDescription
+                            showingErrorAlert = true
+                        }
+                    }
+                }
+            }
+        }
+        .task {
+            isServiceActivated = await config.isActivated
+        }
+        .alert("Unable to Enable \(config.name)", isPresented: $showingErrorAlert) {
+            Button("OK") {}
+        } message: {
+            Text(activationError ?? "An unknown error occurred.")
+        }
+    }
+
+    private var serviceIcon: some View {
+        Circle()
+            .fill(config.binding.wrappedValue ? config.color : Color(NSColor.controlColor).opacity(0.3))
+            .frame(width: 26, height: 26)
+            .overlay(
+                Image(systemName: config.iconName)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundColor(config.binding.wrappedValue ? .white : .primary.opacity(0.5))
+                    .padding(5)
+            )
+            .animation(.snappy, value: config.binding.wrappedValue)
+    }
+}

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -2,30 +2,25 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var serverController: ServerController
-    @State private var selectedSection: SettingsSection? = .general
+    @State private var selectedSection: SettingsSection? = .services
 
     enum SettingsSection: String, CaseIterable, Identifiable {
+        case services = "Services"
         case general = "General"
 
         var id: String { self.rawValue }
 
         var icon: String {
             switch self {
+            case .services: return "square.grid.2x2"
             case .general: return "gear"
             }
         }
     }
 
     var body: some View {
-        NavigationView {
-            List(
-                selection: .init(
-                    get: { selectedSection },
-                    set: { section in
-                        selectedSection = section
-                    }
-                )
-            ) {
+        NavigationSplitView {
+            List(selection: $selectedSection) {
                 Section {
                     ForEach(SettingsSection.allCases) { section in
                         Label(section.rawValue, systemImage: section.icon)
@@ -33,9 +28,12 @@ struct SettingsView: View {
                     }
                 }
             }
-
+        } detail: {
             if let selectedSection {
                 switch selectedSection {
+                case .services:
+                    ServiceSettingsView(serverController: serverController)
+                        .navigationTitle("Services")
                 case .general:
                     GeneralSettingsView(serverController: serverController)
                         .navigationTitle("General")
@@ -54,11 +52,6 @@ struct SettingsView: View {
             let window = NSApplication.shared.keyWindow
             window?.toolbarStyle = .unified
             window?.toolbar?.displayMode = .iconOnly
-        }
-        .onAppear {
-            if selectedSection == nil, let firstSection = SettingsSection.allCases.first {
-                selectedSection = firstSection
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors the menu bar and settings UI to handle growing number of services, as outlined in issue #7.

- Simplifies menu bar by replacing individual service toggles with a single "Services (N enabled)" entry
- Adds new Services tab to Settings with services grouped by category
- Introduces ServiceCategory enum for organizing services (Personal Data, Productivity, Media & Home, System)
- Prepares infrastructure for future granular service controls via hasDetailView flag

## Changes

### Data Model
- Added `ServiceCategory` enum with 4 categories
- Extended `ServiceConfig` with `category` and `hasDetailView` properties
- Added `enabledServicesCount` computed property to `ServerController`

### New Views
- `ServiceSettingsView` - Categorized service list with toggles

### Modified Views
- `ContentView` - Removed service toggles, added "Services (N enabled)" menu item
- `SettingsView` - Added Services tab as default section

### Bug Fixes
- Fixed Settings window not always opening by adding `NSApp.activate(ignoringOtherApps: true)`
- Added guard to prevent `updateServiceBindings` race condition on launch (related to #8)

## Test Plan

- [x] Build succeeds
- [x] Menu bar shows "Services (N enabled)" instead of individual toggles
- [x] Clicking "Services" or "Settings" reliably opens Settings window
- [x] Services tab shows services grouped by category
- [x] Service toggles work correctly in Settings
- [x] No crash on immediate menu interaction after launch

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)