### PR TITLE
Fix #12: Weather timeout protection and sandbox path fix

### DIFF
--- a/App/Services/Weather.swift
+++ b/App/Services/Weather.swift
@@ -37,7 +37,9 @@ final class WeatherService: Service {
                 throw WeatherTimeoutError()
             }
 
-            let result = try await group.next()!
+            guard let result = try await group.next() else {
+                throw WeatherTimeoutError()
+            }
             group.cancelAll()
             return result
         }


### PR DESCRIPTION
## Summary

- Add 30-second timeout protection for WeatherKit API calls to prevent indefinite hangs
- Fix CLI to find transport.json in sandboxed app container path

## Changes

### Weather Timeout Protection (`App/Services/Weather.swift`)
- Add `WeatherTimeoutError` with descriptive error message
- Add `withTimeout` helper using Swift concurrency task group racing pattern
- Wrap all four weather tools (current, daily, hourly, minute) with 30s timeout
- Add logging before each weather fetch for debugging

### Sandbox Path Fix (`CLI/main.swift`)
- CLI now checks multiple paths for `transport.json`:
  1. `~/Library/Application Support/iMCP/transport.json` (non-sandboxed)
  2. `~/Library/Containers/com.appjawn.iMCP/Data/.../transport.json` (sandboxed)
- Uses whichever path exists first
- Works regardless of whether app runs sandboxed or not

## Test plan

- [x] Build succeeds
- [x] CLI finds transport.json in sandboxed path
- [x] iMCP connects successfully via Claude Code MCP
- [ ] Weather calls return timeout error after 30s if WeatherKit hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)