### PR TITLE
Add #14 #16: Reminder lifecycle tools

### DIFF
--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -1,9 +1,62 @@
 import EventKit
 import Foundation
+import MCP
 import OSLog
 import Ontology
 
 private let log = Logger.service("reminders")
+
+/// Converts an EKReminder to a Value object with identifier for MCP responses
+private func reminderToValue(_ reminder: EKReminder) -> Value {
+    var dict: [String: Value] = [
+        "identifier": .string(reminder.calendarItemIdentifier),
+        "title": .string(reminder.title ?? ""),
+        "isCompleted": .bool(reminder.isCompleted),
+        "priority": .string(EKReminderPriority(rawValue: UInt(reminder.priority))?.stringValue ?? "none"),
+        "list": .string(reminder.calendar?.title ?? ""),
+    ]
+
+    if let notes = reminder.notes, !notes.isEmpty {
+        dict["notes"] = .string(notes)
+    }
+
+    if let dueDateComponents = reminder.dueDateComponents,
+        let dueDate = Calendar.current.date(from: dueDateComponents)
+    {
+        dict["due"] = .string(ISO8601DateFormatter().string(from: dueDate))
+    }
+
+    if let completionDate = reminder.completionDate {
+        dict["completedAt"] = .string(ISO8601DateFormatter().string(from: completionDate))
+    }
+
+    if let creationDate = reminder.creationDate {
+        dict["createdAt"] = .string(ISO8601DateFormatter().string(from: creationDate))
+    }
+
+    if let lastModifiedDate = reminder.lastModifiedDate {
+        dict["modifiedAt"] = .string(ISO8601DateFormatter().string(from: lastModifiedDate))
+    }
+
+    if let alarms = reminder.alarms, !alarms.isEmpty {
+        dict["alarms"] = .array(alarms.compactMap { alarm -> Value? in
+            if let absoluteDate = alarm.absoluteDate {
+                return .object([
+                    "type": .string("absolute"),
+                    "datetime": .string(ISO8601DateFormatter().string(from: absoluteDate))
+                ])
+            } else {
+                let minutes = Int(-alarm.relativeOffset / 60)
+                return .object([
+                    "type": .string("relative"),
+                    "minutes": .int(minutes)
+                ])
+            }
+        })
+    }
+
+    return .object(dict)
+}
 
 final class RemindersService: Service {
     private let eventStore = EKEventStore()
@@ -123,8 +176,28 @@ final class RemindersService: Service {
             }
 
             // Create predicate based on completion status
+            // Handle bool, int (JSON false=0, true=1), and string representations
             let predicate: NSPredicate
-            if case let .bool(completed) = arguments["completed"] {
+            let completedArg = arguments["completed"]
+            let completedValue: Bool?
+            switch completedArg {
+            case .bool(let value):
+                completedValue = value
+            case .int(let value):
+                completedValue = (value != 0)
+            case .string(let str):
+                switch str.lowercased() {
+                case "true": completedValue = true
+                case "false": completedValue = false
+                default: completedValue = nil
+                }
+            default:
+                completedValue = nil
+            }
+
+            log.debug("reminders_fetch: completed arg=\(String(describing: completedArg)), parsed=\(String(describing: completedValue))")
+
+            if let completed = completedValue {
                 if completed {
                     predicate = self.eventStore.predicateForCompletedReminders(
                         withCompletionDateStarting: startDate,
@@ -139,7 +212,7 @@ final class RemindersService: Service {
                     )
                 }
             } else {
-                // If completion status not specified, use incomplete predicate as default
+                // If completion status not specified, fetch all reminders
                 predicate = self.eventStore.predicateForReminders(in: reminderLists)
             }
 
@@ -162,7 +235,7 @@ final class RemindersService: Service {
                 }
             }
 
-            return filteredReminders.map { PlanAction($0) }
+            return filteredReminders.map { reminderToValue($0) }
         }
 
         Tool(
@@ -255,7 +328,305 @@ final class RemindersService: Service {
             // Save the reminder
             try self.eventStore.save(reminder, commit: true)
 
-            return PlanAction(reminder)
+            return reminderToValue(reminder)
+        }
+
+        Tool(
+            name: "reminders_get",
+            description: "Fetch a single reminder by its identifier",
+            inputSchema: .object(
+                properties: [
+                    "identifier": .string(
+                        description: "The unique identifier of the reminder"
+                    )
+                ],
+                required: ["identifier"],
+                additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Get Reminder",
+                readOnlyHint: true,
+                openWorldHint: false
+            )
+        ) { arguments in
+            try await self.activate()
+
+            guard EKEventStore.authorizationStatus(for: .reminder) == .fullAccess else {
+                log.error("Reminders access not authorized")
+                throw NSError(
+                    domain: "RemindersError", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminders access not authorized"]
+                )
+            }
+
+            guard case let .string(identifier) = arguments["identifier"] else {
+                throw NSError(
+                    domain: "RemindersError", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder identifier is required"]
+                )
+            }
+
+            guard let item = self.eventStore.calendarItem(withIdentifier: identifier),
+                let reminder = item as? EKReminder
+            else {
+                throw NSError(
+                    domain: "RemindersError", code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder not found with identifier: \(identifier)"]
+                )
+            }
+
+            return reminderToValue(reminder)
+        }
+
+        Tool(
+            name: "reminders_complete",
+            description: "Mark one or more reminders as completed or incomplete",
+            inputSchema: .object(
+                properties: [
+                    "identifiers": .array(
+                        description: "The unique identifiers of the reminders to update",
+                        items: .string()
+                    ),
+                    "completed": .boolean(
+                        description: "Set to true to mark as completed, false to mark as incomplete",
+                        default: true
+                    )
+                ],
+                required: ["identifiers"],
+                additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Complete Reminders",
+                destructiveHint: true,
+                openWorldHint: false
+            )
+        ) { arguments in
+            try await self.activate()
+
+            guard EKEventStore.authorizationStatus(for: .reminder) == .fullAccess else {
+                log.error("Reminders access not authorized")
+                throw NSError(
+                    domain: "RemindersError", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminders access not authorized"]
+                )
+            }
+
+            guard case let .array(identifierValues) = arguments["identifiers"],
+                !identifierValues.isEmpty
+            else {
+                throw NSError(
+                    domain: "RemindersError", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "At least one reminder identifier is required"]
+                )
+            }
+
+            let identifiers = identifierValues.compactMap { $0.stringValue }
+            let completed = arguments["completed"]?.boolValue ?? true
+
+            var updatedReminders: [EKReminder] = []
+
+            for identifier in identifiers {
+                guard let item = self.eventStore.calendarItem(withIdentifier: identifier),
+                    let reminder = item as? EKReminder
+                else {
+                    log.warning("Reminder not found: \(identifier, privacy: .public)")
+                    continue
+                }
+
+                reminder.isCompleted = completed
+                try self.eventStore.save(reminder, commit: false)
+                updatedReminders.append(reminder)
+            }
+
+            try self.eventStore.commit()
+
+            return updatedReminders.map { reminderToValue($0) }
+        }
+
+        Tool(
+            name: "reminders_update",
+            description: "Update an existing reminder's properties",
+            inputSchema: .object(
+                properties: [
+                    "identifier": .string(
+                        description: "The unique identifier of the reminder to update"
+                    ),
+                    "title": .string(
+                        description: "New title for the reminder"
+                    ),
+                    "due": .string(
+                        description: "New due date (ISO 8601 format), or null to clear",
+                        format: .dateTime
+                    ),
+                    "notes": .string(
+                        description: "New notes for the reminder"
+                    ),
+                    "list": .string(
+                        description: "Move reminder to a different list"
+                    ),
+                    "priority": .string(
+                        description: "New priority level",
+                        enum: EKReminderPriority.allCases.map { .string($0.stringValue) }
+                    ),
+                    "alarms": .array(
+                        description: "Replace alarms with new ones (minutes before due date)",
+                        items: .integer()
+                    )
+                ],
+                required: ["identifier"],
+                additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Update Reminder",
+                destructiveHint: true,
+                openWorldHint: false
+            )
+        ) { arguments in
+            try await self.activate()
+
+            guard EKEventStore.authorizationStatus(for: .reminder) == .fullAccess else {
+                log.error("Reminders access not authorized")
+                throw NSError(
+                    domain: "RemindersError", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminders access not authorized"]
+                )
+            }
+
+            guard case let .string(identifier) = arguments["identifier"] else {
+                throw NSError(
+                    domain: "RemindersError", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder identifier is required"]
+                )
+            }
+
+            guard let item = self.eventStore.calendarItem(withIdentifier: identifier),
+                let reminder = item as? EKReminder
+            else {
+                throw NSError(
+                    domain: "RemindersError", code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder not found with identifier: \(identifier)"]
+                )
+            }
+
+            guard reminder.calendar.allowsContentModifications else {
+                throw NSError(
+                    domain: "RemindersError", code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder list '\(reminder.calendar.title)' is read-only"]
+                )
+            }
+
+            // Update title if provided
+            if case let .string(title) = arguments["title"] {
+                reminder.title = title
+            }
+
+            // Update due date if provided
+            if let dueValue = arguments["due"] {
+                if case let .string(dueDateStr) = dueValue,
+                    let dueDate = ISO8601DateFormatter.parseFlexibleISODate(dueDateStr)
+                {
+                    reminder.dueDateComponents = Calendar.current.dateComponents(
+                        [.year, .month, .day, .hour, .minute, .second], from: dueDate)
+                } else if case .null = dueValue {
+                    reminder.dueDateComponents = nil
+                }
+            }
+
+            // Update notes if provided
+            if case let .string(notes) = arguments["notes"] {
+                reminder.notes = notes
+            }
+
+            // Move to different list if provided
+            if case let .string(listName) = arguments["list"] {
+                if let matchingCalendar = self.eventStore.calendars(for: .reminder)
+                    .first(where: { $0.title.lowercased() == listName.lowercased() })
+                {
+                    guard matchingCalendar.allowsContentModifications else {
+                        throw NSError(
+                            domain: "RemindersError", code: 4,
+                            userInfo: [NSLocalizedDescriptionKey: "Target list '\(matchingCalendar.title)' is read-only"]
+                        )
+                    }
+                    reminder.calendar = matchingCalendar
+                }
+            }
+
+            // Update priority if provided
+            if case let .string(priorityStr) = arguments["priority"] {
+                reminder.priority = Int(EKReminderPriority.from(string: priorityStr).rawValue)
+            }
+
+            // Replace alarms if provided
+            if case let .array(alarmMinutes) = arguments["alarms"] {
+                reminder.alarms = alarmMinutes.compactMap {
+                    guard case let .int(minutes) = $0 else { return nil }
+                    return EKAlarm(relativeOffset: TimeInterval(-minutes * 60))
+                }
+            }
+
+            try self.eventStore.save(reminder, commit: true)
+
+            return reminderToValue(reminder)
+        }
+
+        Tool(
+            name: "reminders_delete",
+            description: "Delete a reminder",
+            inputSchema: .object(
+                properties: [
+                    "identifier": .string(
+                        description: "The unique identifier of the reminder to delete"
+                    )
+                ],
+                required: ["identifier"],
+                additionalProperties: false
+            ),
+            annotations: .init(
+                title: "Delete Reminder",
+                destructiveHint: true,
+                openWorldHint: false
+            )
+        ) { arguments in
+            try await self.activate()
+
+            guard EKEventStore.authorizationStatus(for: .reminder) == .fullAccess else {
+                log.error("Reminders access not authorized")
+                throw NSError(
+                    domain: "RemindersError", code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminders access not authorized"]
+                )
+            }
+
+            guard case let .string(identifier) = arguments["identifier"] else {
+                throw NSError(
+                    domain: "RemindersError", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder identifier is required"]
+                )
+            }
+
+            guard let item = self.eventStore.calendarItem(withIdentifier: identifier),
+                let reminder = item as? EKReminder
+            else {
+                throw NSError(
+                    domain: "RemindersError", code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder not found with identifier: \(identifier)"]
+                )
+            }
+
+            guard reminder.calendar.allowsContentModifications else {
+                throw NSError(
+                    domain: "RemindersError", code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "Reminder list '\(reminder.calendar.title)' is read-only"]
+                )
+            }
+
+            // Capture reminder details before deletion for response
+            let deletedInfo = reminderToValue(reminder)
+
+            try self.eventStore.remove(reminder, commit: true)
+
+            return deletedInfo
         }
     }
 }


### PR DESCRIPTION
## Summary

Completes the CRUD lifecycle for reminders, enabling full task management through AI assistants.

**New tools:**
- `reminders_get` - Fetch single reminder by identifier
- `reminders_complete` - Mark reminders done/undone (supports batch operations)
- `reminders_update` - Modify title, due date, notes, list, priority, alarms
- `reminders_delete` - Remove reminder (with read-only list protection)

**Bug fixes in `reminders_fetch`:**
- Fix `completed` filter not working (now handles bool/int/string representations)
- Add `identifier` field to response (was missing, blocking use of other tools)
- Replace `PlanAction` with custom `reminderToValue()` for richer response data

## Test plan

- [x] Build succeeds
- [x] `reminders_fetch` with `completed: false` returns only incomplete reminders
- [x] `reminders_fetch` response includes `identifier` field
- [ ] `reminders_get` fetches reminder by ID
- [ ] `reminders_complete` marks reminder as done
- [ ] `reminders_update` modifies reminder properties
- [ ] `reminders_delete` removes reminder

Closes #14, closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)