### PR TITLE
Add #15: Event lifecycle tools (get, update, delete)

### DIFF
--- a/App/Extensions/EventKit+Extensions.swift
+++ b/App/Extensions/EventKit+Extensions.swift
@@ -74,3 +74,24 @@ extension EKReminderPriority {
         }
     }
 }
+
+extension EKSpan {
+    init(_ string: String) {
+        switch string.lowercased() {
+        case "futureevents": self = .futureEvents
+        default: self = .thisEvent
+        }
+    }
+
+    static var allCases: [EKSpan] {
+        return [.thisEvent, .futureEvents]
+    }
+
+    var stringValue: String {
+        switch self {
+        case .thisEvent: return "thisEvent"
+        case .futureEvents: return "futureEvents"
+        @unknown default: return "thisEvent"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes the CRUD lifecycle for calendar events, enabling full event management through AI assistants.

**New tools:**
- `events_get` - Fetch single event by identifier
- `events_update` - Modify event properties (title, dates, location, notes, URL, calendar, availability, alarms)
- `events_delete` - Remove event from calendar

**Features:**
- Partial update support (only modify fields provided)
- Date validation (end >= start)
- Calendar move support with read-only protection
- Recurring event handling via `span` parameter (thisEvent/futureEvents)
- Consistent error messages with available calendars listed on not-found

**Also includes:**
- `eventToValue()` helper for consistent response format with identifiers
- `EKSpan` extension for string conversion
- Updated `events_fetch` and `events_create` to include identifiers in response

## Test plan

- [ ] Build succeeds
- [ ] `events_fetch` returns events with `identifier` field
- [ ] `events_get` fetches event by ID
- [ ] `events_update` modifies event properties
- [ ] `events_update` validates end >= start
- [ ] `events_update` with invalid calendar returns helpful error
- [ ] `events_delete` removes event
- [ ] `span: futureEvents` affects recurring event series

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)