### PR TITLE
Fix #26: Reduce MCP tool schema token footprint

### DIFF
--- a/App/Services/Calendar.swift
+++ b/App/Services/Calendar.swift
@@ -102,7 +102,7 @@ final class CalendarService: Service {
     var tools: [Tool] {
         Tool(
             name: "calendars_list",
-            description: "List available calendars",
+            description: "List available calendars. Returns calendar names for filtering events_fetch",
             inputSchema: .object(
                 properties: [:],
                 additionalProperties: false
@@ -286,12 +286,17 @@ final class CalendarService: Service {
                     "calendar": .string(
                         description: "Calendar to use (uses default if not specified)"
                     ),
-                    "location": .string(),
-                    "notes": .string(),
+                    "location": .string(
+                        description: "Event location or address"
+                    ),
+                    "notes": .string(
+                        description: "Additional notes for the event"
+                    ),
                     "url": .string(
                         format: .uri
                     ),
                     "isAllDay": .boolean(
+                        description: "Whether this is an all-day event",
                         default: false
                     ),
                     "availability": .string(
@@ -300,84 +305,9 @@ final class CalendarService: Service {
                         enum: EKEventAvailability.allCases.map { .string($0.stringValue) }
                     ),
                     "alarms": .array(
-                        description: "Alarm configurations for the event",
-                        items: .anyOf(
-                            [
-                                // Relative alarm (minutes before event)
-                                .object(
-                                    properties: [
-                                        "type": .string(
-                                            const: "relative",
-                                        ),
-                                        "minutes": .integer(
-                                            description:
-                                                "Minutes offset from event start (negative for before, positive for after)"
-                                        ),
-                                        "sound": .string(
-                                            description: "Sound name to play when alarm triggers",
-                                            enum: Sound.allCases.map { .string($0.rawValue) }
-                                        ),
-                                        "emailAddress": .string(
-                                            description: "Email address to send notification to"
-                                        ),
-                                    ],
-                                    required: ["minutes"],
-                                    additionalProperties: false
-                                ),
-                                // Absolute alarm (specific date/time)
-                                .object(
-                                    properties: [
-                                        "type": .string(
-                                            const: "absolute",
-                                        ),
-                                        "datetime": .string(
-                                            format: .dateTime
-                                        ),
-                                        "sound": .string(
-                                            description: "Sound name to play when alarm triggers",
-                                            enum: Sound.allCases.map { .string($0.rawValue) }
-                                        ),
-                                        "emailAddress": .string(
-                                            description: "Email address to send notification to"
-                                        ),
-                                    ],
-                                    required: ["datetime"],
-                                    additionalProperties: false
-                                ),
-                                // Proximity alarm (location-based)
-                                .object(
-                                    properties: [
-                                        "type": .string(
-                                            const: "proximity",
-                                        ),
-                                        "proximity": .string(
-                                            description: "Proximity trigger type",
-                                            default: "enter",
-                                            enum: ["enter", "leave"]
-                                        ),
-                                        "locationTitle": .string(),
-                                        "latitude": .number(),
-                                        "longitude": .number(),
-                                        "radius": .number(
-                                            description: "Radius in meters",
-                                            default: .int(200)
-                                        ),
-                                        "sound": .string(
-                                            description: "Sound name to play when alarm triggers",
-                                            enum: Sound.allCases.map { .string($0.rawValue) }
-                                        ),
-                                        "emailAddress": .string(
-                                            description: "Email address to send notification to"
-                                        ),
-                                    ],
-                                    required: ["locationTitle", "latitude", "longitude"],
-                                    additionalProperties: false
-                                ),
-                            ]
-                        )
+                        description: "Minutes before event start for each alarm",
+                        items: .integer()
                     ),
-                    "hasAlarms": .boolean(),
-                    "isRecurring": .boolean(),
                 ],
                 required: ["title", "start", "end"],
                 additionalProperties: false
@@ -478,76 +408,11 @@ final class CalendarService: Service {
             }
 
             // Set alarms
-            if case let .array(alarmConfigs) = arguments["alarms"] {
-                var alarms: [EKAlarm] = []
-
-                for alarmConfig in alarmConfigs {
-                    guard case let .object(config) = alarmConfig else { continue }
-
-                    var alarm: EKAlarm?
-
-                    let alarmType = config["type"]?.stringValue ?? "relative"
-                    switch alarmType {
-                    case "relative":
-                        if case let .int(minutes) = config["minutes"] {
-                            alarm = EKAlarm(relativeOffset: TimeInterval(-minutes * 60))
-                        }
-
-                    case "absolute":
-                        if case let .string(datetimeStr) = config["datetime"],
-                            let absoluteDate = ISO8601DateFormatter.parseFlexibleISODate(
-                                datetimeStr)
-                        {
-                            alarm = EKAlarm(absoluteDate: absoluteDate)
-                        }
-
-                    case "proximity":
-                        if case let .string(locationTitle) = config["locationTitle"],
-                            case let .double(latitude) = config["latitude"],
-                            case let .double(longitude) = config["longitude"]
-                        {
-                            alarm = EKAlarm()
-
-                            // Create structured location
-                            let structuredLocation = EKStructuredLocation(title: locationTitle)
-                            structuredLocation.geoLocation = CLLocation(
-                                latitude: latitude, longitude: longitude)
-
-                            if case let .double(radius) = config["radius"] {
-                                structuredLocation.radius = radius
-                            } else if case let .int(radiusInt) = config["radius"] {
-                                structuredLocation.radius = Double(radiusInt)
-                            }
-
-                            // Set proximity type
-                            let proximityType = config["proximity"]?.stringValue ?? "enter"
-                            let proximity: EKAlarmProximity =
-                                proximityType == "enter" ? .enter : .leave
-                            alarm?.proximity = proximity
-                            alarm?.structuredLocation = structuredLocation
-                        }
-
-                    default:
-                        log.error("Unexpected alarm type encountered: \(alarmType, privacy: .public)")
-                        continue
-                    }
-
-                    guard let alarm = alarm else { continue }
-
-                    if case let .string(soundName) = config["sound"],
-                        Sound(rawValue: soundName) != nil
-                    {
-                        alarm.soundName = soundName
-                    }
-
-                    if case let .string(email) = config["emailAddress"], !email.isEmpty {
-                        alarm.emailAddress = email
-                    }
-
-                    alarms.append(alarm)
+            if case let .array(alarmMinutes) = arguments["alarms"] {
+                event.alarms = alarmMinutes.compactMap {
+                    guard case let .int(minutes) = $0 else { return nil }
+                    return EKAlarm(relativeOffset: TimeInterval(-minutes * 60))
                 }
-
-                event.alarms = alarms
             }
 
             // Save the event

--- a/App/Services/Capture.swift
+++ b/App/Services/Capture.swift
@@ -129,18 +129,6 @@ final class CaptureService: NSObject, Service {
                         default: .string(FlashMode.default.rawValue),
                         enum: FlashMode.allCases.map { .string($0.rawValue) }
                     ),
-                    "autoExposure": .boolean(
-                        description: "Enable automatic exposure and light balancing",
-                        default: true
-                    ),
-                    "autoFocus": .boolean(
-                        description: "Enable automatic focus",
-                        default: true
-                    ),
-                    "autoWhiteBalance": .boolean(
-                        description: "Enable automatic white balance",
-                        default: true
-                    ),
                     "delay": .number(
                         description: "Delay before taking photo, in seconds",
                         default: 1,

--- a/App/Services/Contacts.swift
+++ b/App/Services/Contacts.swift
@@ -123,8 +123,7 @@ final class ContactsService: Service {
     var tools: [Tool] {
         Tool(
             name: "contacts_me",
-            description:
-                "Get contact information about the user, including name, phone number, email, birthday, relations, address, online presence, and occupation. Always run this tool when the user asks a question that requires personal information about themselves.",
+            description: "Get the current user's contact card (name, phone, email, birthday, address, occupation)",
             inputSchema: .object(
                 properties: [:],
                 additionalProperties: false

--- a/App/Services/Location.swift
+++ b/App/Services/Location.swift
@@ -89,7 +89,7 @@ final class LocationService: NSObject, Service, CLLocationManagerDelegate {
     var tools: [Tool] {
         Tool(
             name: "location_current",
-            description: "Get the user's current location",
+            description: "Get the user's current location. Returns coordinates for use with weather and maps tools",
             inputSchema: .object(
                 properties: [:],
                 additionalProperties: false

--- a/App/Services/Maps.swift
+++ b/App/Services/Maps.swift
@@ -256,8 +256,7 @@ final class MapsService: NSObject, Service {
             inputSchema: .object(
                 properties: [
                     "category": .string(
-                        description: "POI category",
-                        enum: MKPointOfInterestCategory.allCases.map { .string($0.stringValue) }
+                        description: "POI category (e.g. restaurant, cafe, hotel, hospital, park, store, museum, airport, gasStation, parking, pharmacy, gym, library, theater, bank)"
                     ),
                     "latitude": .number(),
                     "longitude": .number(),
@@ -462,22 +461,9 @@ final class MapsService: NSObject, Service {
                         default: "standard",
                         enum: ["standard", "satellite", "hybrid", "mutedStandard"]
                     ),
-                    "showPointsOfInterest": .oneOf(
-                        [
-                            .boolean(
-                                description: "Show all (true) or no (false) POIs",
-                                default: false
-                            ),
-                            .array(
-                                description: "Specific POI types to show",
-                                items: .anyOf(
-                                    MKPointOfInterestCategory.allCases.map {
-                                        .string(const: .string($0.stringValue))
-                                    }
-                                ),
-                                minItems: 1
-                            ),
-                        ]
+                    "showPointsOfInterest": .boolean(
+                        description: "Show points of interest on the map",
+                        default: false
                     ),
                     "showBuildings": .boolean(
                         description: "Whether to show buildings",
@@ -532,28 +518,9 @@ final class MapsService: NSObject, Service {
             options.size = CGSize(width: width, height: height)
 
             let filter: MKPointOfInterestFilter
-            switch arguments["showPointsOfInterest"] {
-            case .bool(true), .string("true"):
+            if case .bool(true) = arguments["showPointsOfInterest"] {
                 filter = .includingAll
-            case .bool(false), .string("false"):
-                filter = .excludingAll
-            case let .string(string):
-                do {
-                    let jsonData = string.data(using: .utf8)!
-                    let poiStrings = try JSONDecoder().decode([String].self, from: jsonData)
-                    let categories = poiStrings.compactMap {
-                        MKPointOfInterestCategory.from(string: $0)
-                    }
-                    filter = categories.isEmpty ? .excludingAll : .init(including: categories)
-                } catch {
-                    filter = .excludingAll
-                }
-            case let .array(poiTypes):
-                let categories = poiTypes.compactMap { $0.stringValue }.compactMap {
-                    MKPointOfInterestCategory.from(string: $0)
-                }
-                filter = categories.isEmpty ? .excludingAll : .init(including: categories)
-            default:
+            } else {
                 filter = .excludingAll
             }
             options.pointOfInterestFilter = filter

--- a/App/Services/Reminders.swift
+++ b/App/Services/Reminders.swift
@@ -6,6 +6,24 @@ import Ontology
 
 private let log = Logger.service("reminders")
 
+/// Converts an EKReminder to a summary Value for list responses (reduces token usage)
+private func reminderToSummaryValue(_ reminder: EKReminder) -> Value {
+    var dict: [String: Value] = [
+        "identifier": .string(reminder.calendarItemIdentifier),
+        "title": .string(reminder.title ?? ""),
+        "isCompleted": .bool(reminder.isCompleted),
+        "priority": .string(EKReminderPriority(rawValue: UInt(reminder.priority))?.stringValue ?? "none"),
+        "list": .string(reminder.calendar?.title ?? ""),
+        "hasNotes": .bool(reminder.notes != nil && !reminder.notes!.isEmpty),
+        "hasAlarms": .bool(reminder.alarms != nil && !reminder.alarms!.isEmpty),
+    ]
+    if let dueDateComponents = reminder.dueDateComponents,
+       let dueDate = Calendar.current.date(from: dueDateComponents) {
+        dict["due"] = .string(ISO8601DateFormatter().string(from: dueDate))
+    }
+    return .object(dict)
+}
+
 /// Converts an EKReminder to a Value object with identifier for MCP responses
 private func reminderToValue(_ reminder: EKReminder) -> Value {
     var dict: [String: Value] = [
@@ -76,7 +94,7 @@ final class RemindersService: Service {
     var tools: [Tool] {
         Tool(
             name: "reminders_lists",
-            description: "List available reminder lists",
+            description: "List available reminder lists. Returns list names for filtering reminders_fetch",
             inputSchema: .object(
                 properties: [:],
                 additionalProperties: false
@@ -110,7 +128,7 @@ final class RemindersService: Service {
 
         Tool(
             name: "reminders_fetch",
-            description: "Get reminders from the reminders app with flexible filtering options",
+            description: "Get reminders with filtering. Returns summary data; use reminders_get for full details including notes.",
             inputSchema: .object(
                 properties: [
                     "completed": .boolean(
@@ -244,7 +262,7 @@ final class RemindersService: Service {
                 }
             }
 
-            return filteredReminders.map { reminderToValue($0) }
+            return filteredReminders.map { reminderToSummaryValue($0) }
         }
 
         Tool(
@@ -252,7 +270,9 @@ final class RemindersService: Service {
             description: "Create a new reminder with specified properties",
             inputSchema: .object(
                 properties: [
-                    "title": .string(),
+                    "title": .string(
+                        description: "Title of the reminder"
+                    ),
                     "due": .string(
                         format: .dateTime
                     ),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build Commands
 
-Use `xcsift` to filter xcodebuild output for cleaner, more readable results:
+A Makefile wraps all build commands. Run `make help` to see available targets.
 
 ```bash
-# Build the app (includes CLI target)
-xcodebuild -project iMCP.xcodeproj -scheme iMCP build 2>&1 | xcsift
-
-# Build for release
-xcodebuild -project iMCP.xcodeproj -scheme iMCP -configuration Release build 2>&1 | xcsift
-
-# Clean build
-xcodebuild -project iMCP.xcodeproj -scheme iMCP clean 2>&1 | xcsift
+make build      # Release build
+make debug      # Debug build
+make install    # Build and copy to /Applications
+make clean      # Clean build artifacts and DerivedData
+make run        # Build and launch
+make resolve    # Resolve Swift package dependencies
 ```
 
 The project has two targets:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# iMCP Makefile
+
+PROJECT    := iMCP.xcodeproj
+SCHEME     := iMCP
+APP_NAME   := iMCP.app
+INSTALL_DIR := /Applications
+
+# Resolve DerivedData build products directory
+BUILD_DIR = $(shell xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Release -showBuildSettings 2>/dev/null | grep '^\s*BUILT_PRODUCTS_DIR' | head -1 | awk '{print $$3}')
+
+.PHONY: help build debug install uninstall clean resolve open run
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the app (Release)
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Release build 2>&1 | xcsift
+
+debug: ## Build the app (Debug)
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Debug build 2>&1 | xcsift
+
+install: build ## Build and install to /Applications
+	@echo "Installing $(APP_NAME) to $(INSTALL_DIR)..."
+	@rm -rf "$(INSTALL_DIR)/$(APP_NAME)"
+	@cp -R "$(BUILD_DIR)/$(APP_NAME)" "$(INSTALL_DIR)/$(APP_NAME)"
+	@echo "Installed. You may need to restart the app."
+
+uninstall: ## Remove from /Applications
+	@echo "Removing $(APP_NAME) from $(INSTALL_DIR)..."
+	@rm -rf "$(INSTALL_DIR)/$(APP_NAME)"
+	@echo "Removed."
+
+clean: ## Clean build artifacts and DerivedData
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) clean 2>&1 | xcsift
+	@rm -rf ~/Library/Developer/Xcode/DerivedData/iMCP-*
+	@echo "Clean complete."
+
+resolve: ## Resolve Swift package dependencies
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -resolvePackageDependencies 2>&1 | xcsift
+
+open: ## Open project in Xcode
+	open $(PROJECT)
+
+run: build ## Build and launch the app
+	@open "$(BUILD_DIR)/$(APP_NAME)"


### PR DESCRIPTION
## Summary
- Simplify `events_create` alarms from complex `anyOf` (3 object variants + Sound enums) to simple integer array, matching `events_update` pattern
- Replace `maps_generate` POI `oneOf(boolean, array-of-30-enums)` with simple boolean
- Remove 30-item enum from `maps_explore` category, use freeform string with common values in description
- Add summary/detail pattern for `reminders_fetch` (returns `hasNotes`/`hasAlarms` booleans instead of full content)
- Tighten `contacts_me` description
- Add tool-chaining hints to `calendars_list`, `location_current`, `reminders_lists`
- Remove `autoExposure`/`autoFocus`/`autoWhiteBalance` from `capture_take_picture` schema (handler defaults unchanged)
- Add missing parameter descriptions to `events_create` and `reminders_create`
- Add Makefile for build, install, clean, and other common operations
- Update CLAUDE.md to reference Makefile targets

## Test plan
- [x] Release build passes with 0 errors, 0 warnings
- [ ] `tools/list` returns well-formed schemas for all modified tools
- [ ] `events_create` with `"alarms": [5, 15]` creates event with 2 alarms
- [ ] `maps_generate` with `"showPointsOfInterest": true` works
- [ ] `maps_explore` with `"category": "restaurant"` works; `"invalid"` returns error
- [ ] `reminders_fetch` returns summary with `hasNotes`/`hasAlarms` booleans
- [ ] `reminders_get` with identifier returns full detail
- [ ] `capture_take_picture` with no auto* params uses defaults
- [ ] `make build`, `make install`, `make clean` work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)